### PR TITLE
Handle scaffold topBar and bottomBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 [Article](https://medium.com/proandroiddev/container-transform-animation-98e5e74a15c9)
 
-![anim](https://github.com/user-attachments/assets/94ad445c-dfa3-409f-92c2-2186a1037bbf)
+<img src="https://github.com/user-attachments/assets/004431db-8a86-4e29-9386-cf5772be8431" width="250">

--- a/app/src/main/java/com/rmyhal/containertransform/HomeScreen.kt
+++ b/app/src/main/java/com/rmyhal/containertransform/HomeScreen.kt
@@ -49,13 +49,14 @@ import kotlinx.coroutines.delay
 import me.rmyhal.contentment.Contentment
 
 @Composable
-fun HomeScreen(modifier: Modifier = Modifier) {
+fun HomeScreen(modifier: Modifier = Modifier, setShowNavBars: (Boolean) -> Unit) {
   Box(
     modifier = modifier
       .fillMaxSize(),
   ) {
     HotContent()
     FabContainer(
+      setShowNavBars = setShowNavBars,
       modifier = Modifier
         .align(Alignment.BottomEnd),
     )
@@ -64,6 +65,7 @@ fun HomeScreen(modifier: Modifier = Modifier) {
 
 @Composable
 private fun FabContainer(
+  setShowNavBars: (Boolean) -> Unit,
   modifier: Modifier = Modifier,
 ) {
   var containerState by remember { mutableStateOf(ContainerState.Fab) }
@@ -78,7 +80,7 @@ private fun FabContainer(
       when (state) {
         ContainerState.Fab -> {
           Fab(
-            onClick = { containerState = ContainerState.Fullscreen },
+            onClick = { containerState = ContainerState.Fullscreen; setShowNavBars(false) },
             animatedVisibilityScope = this@AnimatedContent,
             sharedTransitionScope = this@SharedTransitionLayout,
           )
@@ -87,7 +89,7 @@ private fun FabContainer(
         ContainerState.Fullscreen -> {
           AddContentScreen(
             modifier = Modifier,
-            onBack = { containerState = ContainerState.Fab },
+            onBack = { containerState = ContainerState.Fab; setShowNavBars(true) },
             animatedVisibilityScope = this@AnimatedContent,
             sharedTransitionScope = this@SharedTransitionLayout,
           )
@@ -236,6 +238,6 @@ enum class ContainerState {
 @Composable
 private fun Preview() {
   ContainerTransformTheme {
-    HomeScreen()
+    HomeScreen(setShowNavBars = {})
   }
 }

--- a/app/src/main/java/com/rmyhal/containertransform/MainActivity.kt
+++ b/app/src/main/java/com/rmyhal/containertransform/MainActivity.kt
@@ -4,10 +4,29 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Home
+import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.rmyhal.containertransform.ui.theme.ContainerTransformTheme
@@ -17,9 +36,18 @@ class MainActivity : ComponentActivity() {
 		super.onCreate(savedInstanceState)
 		enableEdgeToEdge()
 		setContent {
+			var showNavBars by remember { mutableStateOf(true) }
 			ContainerTransformTheme {
-				Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+				Scaffold(
+					topBar =  {
+						TopNavBar(showNavBars)
+					},
+					bottomBar = {
+						BottomNavBar(showNavBars)
+					},
+					modifier = Modifier.fillMaxSize()) { innerPadding ->
 					HomeScreen(
+						setShowNavBars = { showNavBars = it },
 						modifier = Modifier
 							.padding(innerPadding)
 					)
@@ -27,12 +55,55 @@ class MainActivity : ComponentActivity() {
 			}
 		}
 	}
+
+	@Composable
+	private fun BottomNavBar(showNavBars: Boolean) {
+		AnimatedVisibility(
+			visible = showNavBars,
+			enter = fadeIn() + expandVertically(),
+			exit = fadeOut() + shrinkVertically()
+		) {
+			NavigationBar {
+				NavigationBarItem(
+					selected = true,
+					icon = { Icon(Icons.Rounded.Home, contentDescription = "Home") },
+					label = { Text("Home") },
+					onClick = { /* Handle Home click */ }
+				)
+				NavigationBarItem(
+					selected = false,
+					icon = { Icon(Icons.Rounded.Settings, contentDescription = "Settings") },
+					label = { Text("Settings") },
+					onClick = { /* Handle Settings click */ }
+				)
+				NavigationBarItem(
+					selected = false,
+					icon = { Icon(Icons.Rounded.Info, contentDescription = "About") },
+					label = { Text("About") },
+					onClick = { /* Handle About click */ }
+				)
+			}
+		}
+	}
+
+	@Composable
+	@OptIn(ExperimentalMaterial3Api::class)
+	private fun TopNavBar(showNavBars: Boolean) {
+		AnimatedVisibility(
+			visible = showNavBars,
+			enter = fadeIn() + expandVertically(),
+			exit = fadeOut() + shrinkVertically()
+		) {
+			CenterAlignedTopAppBar(title = { Text("Hot takes") })
+		}
+	}
 }
+
 
 @Preview(showBackground = true)
 @Composable
 private fun Preview() {
 	ContainerTransformTheme {
-		HomeScreen()
+		HomeScreen(setShowNavBars = {})
 	}
 }


### PR DESCRIPTION
First of all thank you for this repository, it was very useful to me! 

In my app, I am making use of the scaffold topBar and bottomBar to show the app title and some navigation buttons at the bottom.

[This](https://m3.material.io/components/floating-action-button/guidelines#49f72f6a-560c-45c0-acb1-d475196cafe8) section from the material 3 guidelines indicates what I am trying to achieve. You can see it has the navbar at the bottom.

I have tried to make the container transform transition work with the fab while using the scaffold topBar and bottomBar. My strategy for this is to conditionally render these bars when the AddContentScreen is shown or not. 

The best way to do this would have been to render the AddContentScreen on top of the topBar and bottomBar but I was not able to do this. My solution is not great because there is a bit of a weird artefact at the top. Let me know if you would have a better way to handle this. For now I will leave this here for anyone trying to do the same. 

Below a gif of the way it works in my solution:

<img src="https://github.com/user-attachments/assets/004431db-8a86-4e29-9386-cf5772be8431" width="250">